### PR TITLE
Fix error 'no attribute HTTPResponse'

### DIFF
--- a/mitmproxy-plugin.py
+++ b/mitmproxy-plugin.py
@@ -2,7 +2,8 @@ import re
 import json
 from mitmproxy import http
 
-path = '/path/to/your/code' # <---change this!!
+battle_filename = 'generated-battle.json' # name of the file you generated with make_team.py
+path = f'/path/to/your/{battle_filename}' # <---change this!!
 
 def request(flow: http.HTTPFlow) -> None:
     if not (flow.request.method == "GET"):

--- a/mitmproxy-plugin.py
+++ b/mitmproxy-plugin.py
@@ -1,19 +1,20 @@
-from mitmproxy import http
 import re
 import json
+from mitmproxy import http
 
+path = '/path/to/your/code' # <---change this!!
 
 def request(flow: http.HTTPFlow) -> None:
     if not (flow.request.method == "GET"):
         return
     if match := re.search("https://api.teamwoodgames.com/api/battle/get/([-a-f0-9]*)", flow.request.pretty_url):
         (battle_id,) = match.groups()
-        with open("/Users/charlie/workspace/super-auto-pets/generated-battle.json") as f:
+        with open(path) as f:
             data = json.load(f)
         data["Id"] = battle_id
-        flow.response = http.HTTPResponse.make(
-            200,  # (optional) status code
-            bytes(json.dumps(data), encoding="utf8"),  # (optional) content
+        flow.response = http.Response.make(
+            200,
+            bytes(json.dumps(data), encoding="utf8"),
             {
                 "Content-Type": "application/json; charset=utf-8",
                 "Access-Control-Allow-Origin": "*"


### PR DESCRIPTION
`mitmproxy.http.HTTPResponse` might've been an old module, but the newest version of the mitmproxy API uses `http.Response.make` to generate a response.

Also, removed personal name in filepath & replaced with variable to make it more general.