### PR TITLE
Remove the need to update whenever the API is updated

### DIFF
--- a/mitmproxy-plugin.py
+++ b/mitmproxy-plugin.py
@@ -3,8 +3,6 @@ import json
 from mitmproxy import http
 
 battle_filename = "generated-battle.json"
-api_version = "0.17"
-beta_api_version = "0.18"
 
 
 def request(flow: http.HTTPFlow) -> None:
@@ -26,9 +24,7 @@ def request(flow: http.HTTPFlow) -> None:
 
 def is_valid_battle_url(url) -> str:
     battle_id = ""
-    if match := re.search(f"https://api.teamwood.games/{api_version}/api/battle/get/([-a-f0-9]*)", url):
-        (battle_id,) = match.groups()
-    elif match := re.search(f"https://staging.teamwood.games/{beta_api_version}/api/battle/get/([-a-f0-9]*)", url):
+    if match := re.search(f"/api/battle/get/([-a-f0-9]*)", url):
         (battle_id,) = match.groups()
 
     return battle_id


### PR DESCRIPTION
The current beta version is 0.18.7 - to avoid having to continually update the tool we can use a different approach for extracting the battle id.

Rather than adding the api and url in the URL checking -- only extract the battle id from the last half of the URL so the tool can be API version agnostic.